### PR TITLE
NAT Track fix

### DIFF
--- a/src/track/trackdownloader.cpp
+++ b/src/track/trackdownloader.cpp
@@ -34,7 +34,7 @@ const QHash<atools::track::TrackType, QString> TrackDownloader::URL =
 {
   // NAT
   // curl  "https://notams.aim.faa.gov/nat.html" > NAT.html
-  {NAT, "https://www.notams.faa.gov/common/nat.html"},
+  {NAT, "https://notams.aim.faa.gov/nat.html"},
 
   // PACOTS
   // https://www.notams.faa.gov/dinsQueryWeb/advancedNotamMapAction.do


### PR DESCRIPTION
This changes the link to the NAT track to https://notams.aim.faa.gov/nat.html instead of https://notams.ain.faa.gov/common/nat.html as referenced here: https://github.com/albar965/littlenavmap/issues/1298

