### PR TITLE
Fix zutil.h for modern masOS versions

### DIFF
--- a/src/zlib/zutil.h
+++ b/src/zlib/zutil.h
@@ -143,8 +143,16 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
 #    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
+       /*
+        * Fix for modern versions of macOS / libc:
+        * fdopen is available but legacy zlib code may incorrectly redefine it.
+        * Do NOT redefine it as NULL, as this breaks <stdio.h>.
+        */
+#      if !defined(HAVE_FDOPEN)
+         /* If fdopen was previously defined as a macro, remove it */
+#        ifdef fdopen
+#          undef fdopen
+#        endif
 #      endif
 #    endif
 #  endif


### PR DESCRIPTION
Hi Alexander,

As agreed you will find in PR a fix for the zlib/zutil.h file to compile the 'atools' project on more modern macOS systems.
It's a little DIY of which I obviously leave it to you to judge the real relevance 😉

Regarding LNM, I have not yet managed to compile the project because I first encountered the installation of the 'Marble' lib which created many problems for me, including the construction of the '$APROJECTS/Marble-release/include/Marble/' folder with the many headers that are not installed by default (GeoData*.h)...

I'll keep you informed.