### PR TITLE
fix missing include statement

### DIFF
--- a/src/zlib/gzlib.c
+++ b/src/zlib/gzlib.c
@@ -5,6 +5,11 @@
 
 #include "gzguts.h"
 
+/* Fix error undeclared function 'lseek' */
+#if defined(__APPLE__) || defined(__unix__)
+#include <unistd.h>
+#endif
+
 #if defined(__DJGPP__)
 #  define LSEEK llseek
 #elif defined(_WIN32) && !defined(__BORLANDC__) && !defined(UNDER_CE)

--- a/src/zlib/gzread.c
+++ b/src/zlib/gzread.c
@@ -5,6 +5,11 @@
 
 #include "gzguts.h"
 
+/* Fix errors undeclared functions 'read' and 'close' */
+#if defined(__APPLE__) || defined(__unix__)
+#include <unistd.h>
+#endif
+
 /* Use read() to load a buffer -- return -1 on error, otherwise 0.  Read from
    state->fd, and update state->eof, state->err, and state->msg as appropriate.
    This function needs to loop on read(), since read() is not guaranteed to

--- a/src/zlib/gzwrite.c
+++ b/src/zlib/gzwrite.c
@@ -5,6 +5,11 @@
 
 #include "gzguts.h"
 
+/* Fix errors undeclared functions 'write' and 'close' */
+#if defined(__APPLE__) || defined(__unix__)
+#include <unistd.h>
+#endif
+
 /* Initialize state for writing a gzip file.  Mark initialization by setting
    state->size to non-zero.  Return -1 on a memory allocation failure, or 0 on
    success. */


### PR DESCRIPTION
Hi Alexander,

With the latest version of 'zlib' I encounter new errors for 'undeclared functions' not supported by modern compilers.
The '#include <unistd.h>' added to the 3 files concerned allows the compilation of 'atools' on my system and will not have an effect on older systems.